### PR TITLE
Update `android update` instructions in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ things as you go.
 - Install Android to ~/android-sdk-macosx/
 - Install Android platform tools, Android 2.3.3 with Google APIs, and the most recent Android with Google APIs (needed for Robolectric). You change the Android version for your project later.
 
-        android update sdk -u --filter platform-tools,android-10,addon-google_apis-google-10,extra-android-support,android-16,addon-google_apis-google-16
+        android update sdk -u --all --filter platform-tools,android-10,addon-google_apis-google-10,extra-android-support,android-16,addon-google_apis-google-16
 
 - Create a local git repo for your new project, or create one on GitHub and clone it. http://help.github.com/create-a-repo/
 - Optionally, fork the robolectric repo on GitHub if you wish to use a fork for your project to make it easy to contribute changes back to robolectric.


### PR DESCRIPTION
`android update` couldn't find a few packages without the `--all` flag set.
Added this to the README.
