### PR TITLE
supports ruby 1.9+

### DIFF
--- a/script/gp
+++ b/script/gp
@@ -1,6 +1,5 @@
 #!/usr/bin/ruby
-
-require "script/helpers"
+require_relative "helpers"
 
 puts <<ART
 

--- a/script/gpp
+++ b/script/gpp
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-require "script/helpers"
+require_relative "helpers"
 
 puts <<ART
 

--- a/script/init_git_repo
+++ b/script/init_git_repo
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-require "script/helpers"
+require_relative "helpers"
 puts <<ART
 Initialize a new git repository
 ART

--- a/script/push_robolectric
+++ b/script/push_robolectric
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-require "script/helpers"
+require_relative "helpers"
 
 in_dir "submodules/robolectric" do
     system! 'git push'

--- a/script/set_package
+++ b/script/set_package
@@ -1,3 +1,3 @@
 #!/usr/bin/ruby
-require "script/helpers"
+require_relative "helpers"
 rename_package

--- a/script/setup_project
+++ b/script/setup_project
@@ -1,6 +1,5 @@
 #!/usr/bin/ruby
-
-require "script/helpers"
+require_relative "helpers"
 
 def display_help_message
   puts <<-eos
@@ -9,7 +8,7 @@ def display_help_message
 
   Example:
      setup_project MyAndroidApp /Users/pivotal/workspace/my-android-app
-     
+
      This command will copy all of the starter project's files to
      your my-android-app directory, rename the IntelliJ project to
      be MyAndroidApp, commit the new files to your project repo, and

--- a/script/update_robolectric
+++ b/script/update_robolectric
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-require "script/helpers"
+require_relative "helpers"
 
 system! 'git submodule update --merge'
 in_dir "submodules/robolectric" do


### PR DESCRIPTION
Old versions of ruby (pre 1.9) added the current directory to the $LOAD_PATH, however new versions of ruby (1.9+) do not. Starting with modern ruby versions 1.9 and greater (including OSX Mavericks, which uses ruby 2.0 for /usr/bin/ruby), the scripts will no longer work correctly, due to this issue. 
This pull request fixes that problem, by using the require_relative method to load the helpers.rb file.

Ruby 1.9+ is now _REQUIRED_ with this change. If we want to support versions prior to ruby 1.9, we can also add this. If so, how old a version would we like to support?
